### PR TITLE
Fixed adding hooks to fields defined in parent classes

### DIFF
--- a/pilo/fields.py
+++ b/pilo/fields.py
@@ -137,7 +137,7 @@ class CreatedCountMixin(object):
 
     _created_count = 0
 
-    def  __init__(self):
+    def __init__(self):
         CreatedCountMixin._created_count += 1
         self._count = CreatedCountMixin._created_count
 
@@ -389,7 +389,7 @@ class Field(CreatedCountMixin, ContextMixin):
         return self.parent is not None
 
     def clone(self):
-        other = copy.copy(self)
+        other = copy.deepcopy(self)
         other.parent = None
         return other
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -374,3 +374,28 @@ class TestFormPolymorphism(TestCase):
             ]:
             obj = Animal.type.cast(desc)(desc)
             self.assertIsInstance(obj, cls)
+
+    def test_override_hook(self):
+        """
+        Test that Sub-classes can independently provide hooks on the fields by
+        cloning.
+        """
+
+        class Item(pilo.Form):
+            price = pilo.fields.Integer()
+
+        class Heirloom(Item):
+
+            has_sentimental_value = pilo.fields.Boolean()
+
+            price = Item.price.clone()
+
+            @price.compute
+            def get_price(self):
+                return 1000000 if self.has_sentimental_value else 0
+
+        item = Item(price=100)
+        self.assertEqual(item.price, 100)
+
+        heirloom = Heirloom(has_sentimental_value=False)
+        self.assertEqual(heirloom.price, 0)


### PR DESCRIPTION
Ran into a situation where I wanted to define a generic field in the parent class, but wanted to be able to override the value using a `@compute` hook in child classes.