### PR TITLE
Added the ability to pass an explicit name for a field.

### DIFF
--- a/pilo/fields.py
+++ b/pilo/fields.py
@@ -302,7 +302,7 @@ class Field(CreatedCountMixin, ContextMixin):
 
     """
 
-    def __init__(self, src=NONE, **options):
+    def __init__(self, src=NONE, name=None, **options):
         super(Field, self).__init__()
 
         # hooks
@@ -316,7 +316,7 @@ class Field(CreatedCountMixin, ContextMixin):
 
         # site
         self.parent = None
-        self.name = None
+        self.name = name
         self.src = src
 
         # options
@@ -372,7 +372,9 @@ class Field(CreatedCountMixin, ContextMixin):
         return '{0}({1})'.format(type(self).__name__, attrs)
 
     def attach(self, parent, name=None):
-        self.parent, self.name = parent, name
+        self.parent = parent
+        if self.name is None:
+            self.name = name
         if self.src is NONE:
             self.src = self.name
         if inspect.isclass(parent) and issubclass(parent, Form):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -374,3 +374,31 @@ class TestFormPolymorphism(TestCase):
             ]:
             obj = Animal.type.cast(desc)(desc)
             self.assertIsInstance(obj, cls)
+
+    def test_explicit_field_name_existing_method(self):
+        """
+        Test that you can use existing dictionary methods for field names.
+        """
+
+        class Form(pilo.Form):
+
+            items_key = pilo.fields.List(pilo.fields.String(), name='items')
+
+        items = ['a', 'b', 'c']
+        form = Form(items=items)
+        self.assertEqual(form['items'], items)
+        self.assertEqual(dict(form.items()), dict(items=items))
+
+    def test_explicit_field_name_reserved_word(self):
+        """
+        Test that you can use existing dictionary methods for field names.
+        """
+
+        class Form(pilo.Form):
+
+            defintion = pilo.fields.Tuple((pilo.fields.String(), pilo.fields.String(), ), name='def')
+
+        definition = ('term', 'definition')
+        form = Form(**{'def': definition})
+        self.assertEqual(form['def'], definition)
+        self.assertEqual(dict(form), {'def': definition})


### PR DESCRIPTION
This permits using existing method names and reserved keywords in your field definitions.